### PR TITLE
Fix Xcode 6.3 warnings.

### DIFF
--- a/AutoLayout/UIView+SDCAutoLayout.m
+++ b/AutoLayout/UIView+SDCAutoLayout.m
@@ -300,7 +300,7 @@ CGFloat const SDCAutoLayoutStandardParentChildDistance = 20;
 	if (spacing >= 0) {
 		constraint = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeRight multiplier:1 constant:spacing];
 	} else {
-		constraint = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeLeft multiplier:1 constant:abs(spacing)];
+		constraint = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeLeft multiplier:1 constant:fabs(spacing)];
 	}
 	
 	[commonAncestor addConstraint:constraint];
@@ -315,7 +315,7 @@ CGFloat const SDCAutoLayoutStandardParentChildDistance = 20;
 	if (spacing >= 0) {
 		constraint = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeBottom multiplier:1 constant:spacing];
 	} else {
-		constraint = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeTop multiplier:1 constant:abs(spacing)];
+		constraint = [NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeTop multiplier:1 constant:fabs(spacing)];
 	}
 	
 	[commonAncestor addConstraint:constraint];


### PR DESCRIPTION
Warning was: "using integer absolute value function 'abs' when argument is of floating point type" and suggestion was "use function 'fabs' instead".